### PR TITLE
Guard against req.body no longer having 'hasOwnProperty'

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -27,7 +27,7 @@ function form() {
 
     if (options.autoLocals) {
       for (var prop in req.body) {
-        if (!req.body.hasOwnProperty(prop)) continue;
+        if (Object.hasOwnProperty.call(req.body, prop)) continue;
 
         /*
          * express 1.x and 3.x


### PR DESCRIPTION
This has been updated in original freewil/express-form (https://github.com/freewil/express-form/commit/9a3236224ca1699af1c703a8f029077ed477fd77)
